### PR TITLE
Include password in direct connect

### DIFF
--- a/Addons/Core/Configs/CfgDirectConnect.hpp
+++ b/Addons/Core/Configs/CfgDirectConnect.hpp
@@ -14,7 +14,7 @@ class CfgMainMenuSpotlight {
 		textIsQuote = 0;
 		picture = "\x\VS_C\core\img\bapmc.paa";
 		video = "";
-		action = "connectToServer [""45.92.44.67"", 2302, """"]"; //This Goes [""IP"", Port, ""Password""], if you dont want the password visible just leave the pasword section empty.
+		action = "connectToServer [""45.92.44.67"", 2302, ""Athena""]"; //This Goes [""IP"", Port, ""Password""], if you dont want the password visible just leave the pasword section empty.
 		actionText = "Connect";
 		condition = true; //Lies
 	};


### PR DESCRIPTION
Is there a real reason not to include the password in the direct connect? Leaving the password blank will just autofill from the last direct connect, which can be annoying for people with multiple servers. Doesn't exactly compromise security, anyone using this mod will be in the unit anyway, and there are easier ways to get hold of the password.